### PR TITLE
dialoguetrigger on unlockable

### DIFF
--- a/Assets/Components/BusinessPrefab/businessPrefabGameObject.prefab
+++ b/Assets/Components/BusinessPrefab/businessPrefabGameObject.prefab
@@ -13,6 +13,7 @@ GameObject:
   - component: {fileID: 2486851645272228491}
   - component: {fileID: 921867341980708537}
   - component: {fileID: 5270383155698329241}
+  - component: {fileID: 3485048968847794191}
   m_Layer: 0
   m_Name: unlockButton
   m_TagString: Untagged
@@ -151,6 +152,21 @@ MonoBehaviour:
   unlockCanvas: {fileID: 3167792555339812208}
   unlockedCanvas: {fileID: 4715354385121623202}
   unlockButton: {fileID: 921867341980708537}
+--- !u!114 &3485048968847794191
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 60277995369059109}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: cb391df5e2ead10449364cf5d2b6ad3e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  dialogue:
+    name: 
+    sentences: []
 --- !u!1 &857097647982690290
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Components/BusinessPrefab/unlockButtonScript.cs
+++ b/Assets/Components/BusinessPrefab/unlockButtonScript.cs
@@ -20,16 +20,21 @@ public class unlockButtonScript : MonoBehaviour
 
     [SerializeField] Button unlockButton;           //button used to make interactable/uninteractable depending on current money
 
+    private dialogueTrigger dialogueTrigger;        //since dialogueTrigger a monoscript we attach and can get component
 
     //SAY I WANT TO ACCESS AN OBJECT THAT IS OUTSIDE THE HIERARCHY LIKE THIS
     //DO I JUST SIMPLY FIND IT??
     totalMoneyScript totalMoneyObject;
+
+
+    bool unlockableDialogueShown = false;
 
     private void Awake()
     {
         //manually find totalMoneyObject and get script to access variable
         totalMoneyObject = GameObject.Find("totalMoney").GetComponent<totalMoneyScript>();    //note this gets only the gameobject
         businessVariables = variableObject.GetComponent<businessVariables>();
+        dialogueTrigger = GetComponent<dialogueTrigger>();
 
     }
 
@@ -45,7 +50,13 @@ public class unlockButtonScript : MonoBehaviour
         //allow clickable button if their is enough money
         if (businessVariables.unlockCost <= totalMoneyObject.totalMoney)
         {
+            if (unlockableDialogueShown == false)
+            {
+                unlockableDialogueShown=true;
+                dialogueTrigger.triggerDialogue();
+            }
             unlockButton.interactable = true;
+
         } else
         {
             unlockButton.interactable = false;

--- a/Assets/Scenes/MainPage.unity
+++ b/Assets/Scenes/MainPage.unity
@@ -993,7 +993,7 @@ GameObject:
   - component: {fileID: 546135996}
   - component: {fileID: 546135997}
   m_Layer: 5
-  m_Name: Circle
+  m_Name: NpcPic
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -2299,6 +2299,34 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 3485048968847794191, guid: 2c2ed76f75ce0b342b8b6188d1598948, type: 3}
+      propertyPath: dialogue.name
+      value: robot1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3485048968847794191, guid: 2c2ed76f75ce0b342b8b6188d1598948, type: 3}
+      propertyPath: dialogue.sentences.Array.size
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 3485048968847794191, guid: 2c2ed76f75ce0b342b8b6188d1598948, type: 3}
+      propertyPath: dialogue.sentences.Array.data[0]
+      value: nice we have our first business
+      objectReference: {fileID: 0}
+    - target: {fileID: 3485048968847794191, guid: 2c2ed76f75ce0b342b8b6188d1598948, type: 3}
+      propertyPath: dialogue.sentences.Array.data[1]
+      value: asdfqrv
+      objectReference: {fileID: 0}
+    - target: {fileID: 3485048968847794191, guid: 2c2ed76f75ce0b342b8b6188d1598948, type: 3}
+      propertyPath: dialogue.sentences.Array.data[2]
+      value: asdfre
+      objectReference: {fileID: 0}
+    - target: {fileID: 3485048968847794191, guid: 2c2ed76f75ce0b342b8b6188d1598948, type: 3}
+      propertyPath: dialogue.sentences.Array.data[3]
+      value: asdvr
+      objectReference: {fileID: 0}
+    - target: {fileID: 3485048968847794191, guid: 2c2ed76f75ce0b342b8b6188d1598948, type: 3}
+      propertyPath: dialogue.sentences.Array.data[4]
+      value: asdgr
+      objectReference: {fileID: 0}
     - target: {fileID: 5622840529765545675, guid: 2c2ed76f75ce0b342b8b6188d1598948, type: 3}
       propertyPath: level
       value: 1
@@ -2488,6 +2516,18 @@ PrefabInstance:
     - target: {fileID: 2910098693919687242, guid: 2c2ed76f75ce0b342b8b6188d1598948, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3485048968847794191, guid: 2c2ed76f75ce0b342b8b6188d1598948, type: 3}
+      propertyPath: dialogue.name
+      value: robot2
+      objectReference: {fileID: 0}
+    - target: {fileID: 3485048968847794191, guid: 2c2ed76f75ce0b342b8b6188d1598948, type: 3}
+      propertyPath: dialogue.sentences.Array.size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3485048968847794191, guid: 2c2ed76f75ce0b342b8b6188d1598948, type: 3}
+      propertyPath: dialogue.sentences.Array.data[0]
+      value: bozosoo
       objectReference: {fileID: 0}
     - target: {fileID: 6227285583134176676, guid: 2c2ed76f75ce0b342b8b6188d1598948, type: 3}
       propertyPath: m_Name


### PR DESCRIPTION
dialogueTrigger was attached to when the business is unlockable and only plays once, if you need to activate a dialogue on a given event, attach dialogue trigger to object w/script, get component of dialogue trigger and modify dialogue and npc name, limitations currently is that only one dialogue at a time, and it always shows up in the same place so i need to find a way to dynamically change where it goes